### PR TITLE
Update dependencies and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ tesseract.process(__dirname + '/path/to/image.jpg', options, function(err, text)
 ```
 
 ## Changelog
+* **0.4.5**: Security update
 * **0.4.4**: Audit fix
 * **0.4.3**: Security update
 * **0.4.2**: Polynomial regular expression used on uncontrolled data

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Forked from https://github.com/desmondmorris/node-tesseract/ to support tesseract v4.
+Forked from https://github.com/desmondmorris/node-tesseract/ to support tesseract version 4 and up to version 5.
 
 # Tesseract for node.js
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Forked from https://github.com/desmondmorris/node-tesseract/ to support tesserac
 
 A simple wrapper for the Tesseract OCR package for node.js
 
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/rona-dinihari/node-tesseract/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/rona-dinihari/node-tesseract/tree/main)
+
 ## Requirements
 
 * Tesseract 3.01 or higher is needed for this to work

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,9 +85,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dawnsparks-node-tesseract",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dawnsparks-node-tesseract",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "dependencies": {
         "glob": "^9.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dawnsparks-node-tesseract",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "author": "Rona Dini Hari <hari.ronadini@gmail.com>",
   "description": "A fork of a simple wrapper for the Tesseract OCR package",
   "main": "index.js",


### PR DESCRIPTION
Upgrade `brace-expansion` to version 2.0.2 for security improvements and clarify Tesseract version support in the README. Add a CircleCI badge and update the version to 0.4.5.